### PR TITLE
Setup and add intergration tests for UserGroupsController. Add UserGroupRepository and other

### DIFF
--- a/SubsTracker.BLL/Interfaces/User/IUserGroupService.cs
+++ b/SubsTracker.BLL/Interfaces/User/IUserGroupService.cs
@@ -9,6 +9,7 @@ namespace SubsTracker.BLL.Interfaces.User;
 public interface IUserGroupService :
     IService<UserGroup, UserGroupDto, CreateUserGroupDto, UpdateUserGroupDto, UserGroupFilterDto>
 {
+    Task<UserGroupDto?> GetById(Guid id, CancellationToken cancellationToken);
     Task<List<UserGroupDto>> GetAll(UserGroupFilterDto? filter, CancellationToken cancellationToken);
     Task<UserGroupDto> Create(Guid userId, CreateUserGroupDto createDto, CancellationToken cancellationToken);
     Task<UserGroupDto> ShareSubscription(Guid groupId, Guid subscriptionId, CancellationToken cancellationToken);

--- a/SubsTracker.BLL/Services/User/UserGroupService.cs
+++ b/SubsTracker.BLL/Services/User/UserGroupService.cs
@@ -7,6 +7,7 @@ using SubsTracker.BLL.Interfaces;
 using SubsTracker.BLL.Interfaces.User;
 using SubsTracker.DAL.Interfaces.Repositories;
 using SubsTracker.DAL.Models.User;
+using SubsTracker.DAL.Repository;
 using SubsTracker.Domain.Enums;
 using SubsTracker.Domain.Exceptions;
 using SubsTracker.Domain.Filter;
@@ -15,14 +16,20 @@ using InvalidOperationException = SubsTracker.Domain.Exceptions.InvalidOperation
 namespace SubsTracker.BLL.Services.User;
 
 public class UserGroupService(
-    IRepository<UserGroup> repository,
+    IUserGroupRepository userGroupRepository,
     IRepository<DAL.Models.User.User> userRepository,
     ISubscriptionRepository subscriptionRepository,
     IGroupMemberService memberService,
     IMapper mapper
-    ) : Service<UserGroup, UserGroupDto, CreateUserGroupDto, UpdateUserGroupDto, UserGroupFilterDto>(repository, mapper),
+    ) : Service<UserGroup, UserGroupDto, CreateUserGroupDto, UpdateUserGroupDto, UserGroupFilterDto>(userGroupRepository, mapper),
     IUserGroupService
 {
+    public async Task<UserGroupDto?> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        var groupWithConnectedEntities = await userGroupRepository.GetById(id, cancellationToken);
+        return mapper.Map<UserGroupDto>(groupWithConnectedEntities);
+    }
+    
     public async Task<List<UserGroupDto>> GetAll(UserGroupFilterDto? filter, CancellationToken cancellationToken)
     {
         var predicate = UserGroupFilterHelper.CreatePredicate(filter);
@@ -52,37 +59,43 @@ public class UserGroupService(
 
     public async Task<UserGroupDto> ShareSubscription(Guid groupId, Guid subscriptionId, CancellationToken cancellationToken)
     {
-        var group = await repository.GetById(groupId, cancellationToken)
+        var group = await userGroupRepository.GetById(groupId, cancellationToken)
                 ?? throw new NotFoundException($"Group with id {groupId} not found.");
         
-        if (group.SharedSubscriptions.Any(sub => sub.Id == subscriptionId))
+        if (group.SharedSubscriptions is not null && group.SharedSubscriptions.Any(s => s.Id == subscriptionId))
         {
             throw new InvalidOperationException($"Subscription with id {subscriptionId} is already shared with group {groupId}");
         }
-
+        
         var subscription = await subscriptionRepository.GetById(subscriptionId, cancellationToken)
                            ?? throw new NotFoundException($"Subscription with id {subscriptionId} not found.");
         
         group.SharedSubscriptions.Add(subscription);
 
-        var updatedGroup = await repository.Update(group, cancellationToken);
+        var updatedGroup = await userGroupRepository.Update(group, cancellationToken);
         return mapper.Map<UserGroupDto>(updatedGroup);
     }
 
     public async Task<UserGroupDto> UnshareSubscription(Guid groupId, Guid subscriptionId, CancellationToken cancellationToken)
     {
-        var group = await repository.GetById(groupId, cancellationToken)
+        var group = await userGroupRepository.GetById(groupId, cancellationToken)
                     ?? throw new NotFoundException($"Group with id {groupId} not found.");
 
         var subscriptionToRemove = group.SharedSubscriptions.FirstOrDefault(s => s.Id == subscriptionId);
         
+        if (group.SharedSubscriptions is null)
+        {
+            throw new InvalidOperationException($"No subscriptions is shared in group with id {groupId}");
+        }
+
         if (subscriptionToRemove is null)
         {
-            throw new ValidationException($"Subscription {subscriptionId} is not shared with group {groupId}");
+            throw new InvalidOperationException($"No subscription is shared in group with id {groupId}");
         }
+        
         group.SharedSubscriptions.Remove(subscriptionToRemove);
 
-        var updatedGroup = await repository.Update(group, cancellationToken);
+        var updatedGroup = await userGroupRepository.Update(group, cancellationToken);
         return mapper.Map<UserGroupDto>(updatedGroup);
     }
 }

--- a/SubsTracker.DAL/DataLayerServiceRegister.cs
+++ b/SubsTracker.DAL/DataLayerServiceRegister.cs
@@ -13,10 +13,11 @@ public static class DataLayerServiceRegister
         var postgreConnectionString = configuration["PostgreConnectionString"];
 
         services.AddDbContext<SubsDbContext>(options =>
-            options.UseNpgsql(postgreConnectionString))
-        .AddScoped(typeof(IRepository<>), typeof(Repository<>))
-        .AddScoped<ISubscriptionRepository, SubscriptionRepository>()
-        .AddScoped<ISubscriptionHistoryRepository, SubscriptionHistoryRepository>();
+                options.UseNpgsql(postgreConnectionString))
+            .AddScoped(typeof(IRepository<>), typeof(Repository<>))
+            .AddScoped<ISubscriptionRepository, SubscriptionRepository>()
+            .AddScoped<ISubscriptionHistoryRepository, SubscriptionHistoryRepository>()
+            .AddScoped<IUserGroupRepository, UserGroupRepository>();
         return services;
     }
 }

--- a/SubsTracker.DAL/Interfaces/Repositories/IUserGroupRepository.cs
+++ b/SubsTracker.DAL/Interfaces/Repositories/IUserGroupRepository.cs
@@ -1,0 +1,8 @@
+using SubsTracker.DAL.Models.User;
+
+namespace SubsTracker.DAL.Interfaces.Repositories;
+
+public interface IUserGroupRepository : IRepository<UserGroup>
+{
+    Task<UserGroup?> GetById(Guid id, CancellationToken cancellationToken);
+}

--- a/SubsTracker.DAL/Models/User/UserGroup.cs
+++ b/SubsTracker.DAL/Models/User/UserGroup.cs
@@ -5,6 +5,6 @@ public class UserGroup : BaseModel
     public string Name { get; set; } = string.Empty;
     public Guid? UserId { get; set; }
     public User? User { get; set; }
-    public List<GroupMember>? Members { get; set; }
-    public List<Subscription.Subscription>? SharedSubscriptions { get; set; }
+    public List<GroupMember>? Members { get; set; } = new();
+    public List<Subscription.Subscription>? SharedSubscriptions { get; set; } = new();
 }

--- a/SubsTracker.DAL/Repository/UserGroupRepository.cs
+++ b/SubsTracker.DAL/Repository/UserGroupRepository.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using SubsTracker.DAL.Interfaces.Repositories;
+using SubsTracker.DAL.Models.User;
+
+namespace SubsTracker.DAL.Repository;
+
+public class UserGroupRepository(SubsDbContext context) : Repository<UserGroup>(context), IUserGroupRepository
+{
+    public async Task<UserGroup?> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        var i = await context.UserGroups
+            .Include(g => g.SharedSubscriptions)
+            .Include(g => g.Members)
+            .FirstOrDefaultAsync(g => g.Id == id, cancellationToken);
+        return i;
+    }
+}

--- a/SubsTracker.IntegrationTests/Constants/DatabaseConstant.cs
+++ b/SubsTracker.IntegrationTests/Constants/DatabaseConstant.cs
@@ -1,0 +1,6 @@
+namespace SubsTracker.IntegrationTests.Constants;
+
+public static class DatabaseConstant
+{
+    public const string InMemoryDbName = "InMemoryDbContextTest";
+}

--- a/SubsTracker.IntegrationTests/DataSeedEntites/UserGroupSeedEntity.cs
+++ b/SubsTracker.IntegrationTests/DataSeedEntites/UserGroupSeedEntity.cs
@@ -1,0 +1,9 @@
+namespace SubsTracker.IntegrationTests.DataSeedEntites;
+
+public class UserGroupSeedEntity
+{
+    public User User { get; set; }
+    public Group Group { get; set; }
+    public List<SubscriptionModel> Subscriptions { get; set; }
+    public List<GroupMember> Members { get; set; }
+}

--- a/SubsTracker.IntegrationTests/GlobalUsings.cs
+++ b/SubsTracker.IntegrationTests/GlobalUsings.cs
@@ -1,5 +1,5 @@
-global using SubsTracker.DAL.Models.Subscription;
 global using UserModel = SubsTracker.DAL.Models.User.User;
+global using Group = SubsTracker.DAL.Models.User.UserGroup;
 global using SubscriptionModel = SubsTracker.DAL.Models.Subscription.Subscription;
 global using System.Net.Http.Json;
 global using Newtonsoft.Json;
@@ -13,6 +13,10 @@ global using AutoFixture;
 global using SubsTracker.Domain.Enums;
 global using Microsoft.AspNetCore.Mvc.Testing;
 global using Microsoft.EntityFrameworkCore;
-global using SubsTracker.IntegrationTests.Helpers;
 global using SubsTracker.IntegrationTests.DataSeedEntites;
 global using SubsTracker.DAL.Models.User;
+global using SubsTracker.IntegrationTests.Helpers.Subscription;
+global using SubsTracker.API.ViewModel.User;
+global using SubsTracker.IntegrationTests.Helpers.UserGroup;
+global using SubsTracker.BLL.DTOs.User.Create;
+global using SubsTracker.BLL.DTOs.User.Update;

--- a/SubsTracker.IntegrationTests/Helpers/UserGroup/UserGroupTestsAssertionHelper.cs
+++ b/SubsTracker.IntegrationTests/Helpers/UserGroup/UserGroupTestsAssertionHelper.cs
@@ -1,0 +1,160 @@
+namespace SubsTracker.IntegrationTests.Helpers.UserGroup;
+
+public class UserGroupTestsAssertionHelper(TestsWebApplicationFactory factory) : TestHelperBase(factory) 
+{
+    private readonly IServiceScope _scope = factory.Services.CreateScope();
+
+    public async Task GetByIdHappyPathAssert(HttpResponseMessage response, Group expected)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var viewModel = JsonConvert.DeserializeObject<UserGroupViewModel>(content);
+
+        viewModel.ShouldNotBeNull();
+        viewModel.Id.ShouldBe(expected.Id);
+        viewModel.Name.ShouldBe(expected.Name);
+    }
+
+    public async Task GetAllHappyPathAssert(HttpResponseMessage response, string expectedName)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonConvert.DeserializeObject<List<UserGroupViewModel>>(content);
+
+        result.ShouldNotBeNull();
+        result.ShouldContain(g => g.Name == expectedName);
+    }
+
+    public async Task GetAllSadPathAssert(HttpResponseMessage response)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonConvert.DeserializeObject<List<UserGroupViewModel>>(content);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
+    }
+
+    public async Task CreateHappyPathAssert(HttpResponseMessage response, CreateUserGroupDto expected)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var viewModel = JsonConvert.DeserializeObject<UserGroupViewModel>(content);
+
+        viewModel.ShouldNotBeNull();
+        viewModel.Name.ShouldBe(expected.Name);
+
+        var db = _scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        var entity = await db.UserGroups.FindAsync(viewModel.Id);
+
+        entity.ShouldNotBeNull();
+        entity!.Name.ShouldBe(expected.Name);
+    }
+
+    public async Task UpdateHappyPathAssert(HttpResponseMessage response, Guid groupId, string expectedName)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var viewModel = JsonConvert.DeserializeObject<UserGroupViewModel>(content);
+
+        viewModel.ShouldNotBeNull();
+        viewModel.Id.ShouldBe(groupId);
+        viewModel.Name.ShouldBe(expectedName);
+
+        var db = _scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        var entity = await db.UserGroups.FindAsync(groupId);
+
+        entity.ShouldNotBeNull();
+        entity!.Name.ShouldBe(expectedName);
+    }
+
+    public async Task DeleteHappyPathAssert(HttpResponseMessage response, Guid groupId)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var db = _scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        var entity = await db.UserGroups.FindAsync(groupId);
+
+        entity.ShouldBeNull();
+    }
+    
+    public async Task GetAllMembersHappyPathAssert(HttpResponseMessage response, UserGroupSeedEntity seedEntity, MemberRole targetRole)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var members = JsonConvert.DeserializeObject<List<GroupMemberViewModel>>(content);
+        
+        members.ShouldNotBeNull();
+        members.ShouldAllBe(m => m.Role == targetRole);
+
+        var expected = seedEntity.Members.First(m => m.Role == targetRole);
+        var actual = members.FirstOrDefault(m => m.Id == expected.Id);
+
+        actual.ShouldNotBeNull();
+        actual.Role.ShouldBe(targetRole);
+    }
+    
+    public async Task JoinGroupHappyPathAssert(HttpResponseMessage response, CreateGroupMemberDto createDto)
+    {
+        response.EnsureSuccessStatusCode();
+        
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        var member = await db.Members.FirstOrDefaultAsync(m =>
+            m.UserId == createDto.UserId && m.GroupId == createDto.GroupId);
+
+        member.ShouldNotBeNull();
+        member.Role.ShouldBe(MemberRole.Participant);
+    }
+
+    public async Task LeaveGroupHappyPathAssert(HttpResponseMessage response ,Guid groupId, Guid userId)
+    {
+        response.EnsureSuccessStatusCode();
+        
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        var exists = await db.Members.AnyAsync(m =>
+            m.UserId == userId && m.GroupId == groupId);
+
+        exists.ShouldBeFalse();
+    }
+    
+    public async Task ChangeRoleHappyPathAssert(HttpResponseMessage response, MemberRole expectedRole)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var updated = JsonConvert.DeserializeObject<GroupMemberViewModel>(content);
+        
+        updated.ShouldNotBeNull();
+        updated.Role.ShouldBe(expectedRole);
+    }
+
+    public async Task ShareSubscriptionHappyPathAssert(HttpResponseMessage response)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var updated = JsonConvert.DeserializeObject<UserGroupViewModel>(content);
+
+        updated.ShouldNotBeNull();
+    }
+
+    public async Task UnshareSubscriptionHappyPathAssert(HttpResponseMessage response)
+    {
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var updated = JsonConvert.DeserializeObject<UserGroupViewModel>(content);
+
+        updated.ShouldNotBeNull();
+    }
+}

--- a/SubsTracker.IntegrationTests/Helpers/UserGroup/UserGroupTestsDataSeedingHelper.cs
+++ b/SubsTracker.IntegrationTests/Helpers/UserGroup/UserGroupTestsDataSeedingHelper.cs
@@ -1,0 +1,294 @@
+namespace SubsTracker.IntegrationTests.Helpers.UserGroup;
+
+public class UserGroupTestsDataSeedingHelper(TestsWebApplicationFactory factory) : TestHelperBase(factory)
+{
+    public async Task<UserGroupSeedEntity> AddOnlyUserGroup()
+    {
+        using var scope = CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        
+        var group = _fixture.Build<Group>()
+            .With(g => g.Name, "Test Group")
+            .Without(g => g.Members)
+            .Without(g => g.SharedSubscriptions)
+            .Without(g => g.User)
+            .Without(g => g.UserId)
+            .Create();
+        
+        await dbContext.UserGroups.AddAsync(group);
+        await dbContext.SaveChangesAsync(default); 
+        
+        return new UserGroupSeedEntity
+        {
+            User = null,
+            Group = group,
+            Subscriptions = new List<SubscriptionModel>(),
+            Members = new List<GroupMember>( )
+        };
+    }
+    
+    public async Task<UserGroupSeedEntity> AddUserGroupWithMembers()
+    {
+        using var scope = CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        
+        var owner = _fixture.Build<User>()
+            .Without(u => u.Groups)
+            .Without(u => u.Subscriptions)
+            .Create();
+        
+        var memberUsers = _fixture.CreateMany<User>(3)
+            .Select(u => _fixture.Build<User>().Without(u => u.Groups).Without(u => u.Subscriptions).Create())
+            .ToList();
+        
+        var ownerMember = _fixture.Build<GroupMember>()
+            .With(m => m.UserId, owner.Id)
+            .With(m => m.Role, MemberRole.Admin)
+            .Without(m => m.Group)
+            .Without(m => m.User)
+            .Create();
+        
+        var participantMembers = _fixture.Build<GroupMember>()
+            .With(m => m.Role, MemberRole.Participant)
+            .Without(m => m.Group)
+            .Without(m => m.User)
+            .CreateMany(3).ToList();
+        
+        for (int i = 0; i < participantMembers.Count; i++)
+        {
+            participantMembers[i].UserId = memberUsers[i].Id;
+        }
+        
+        var allMembers = new List<GroupMember>();
+        allMembers.Add(ownerMember);
+        allMembers.AddRange(participantMembers);
+        
+        var group = _fixture.Build<Group>()
+            .With(g => g.UserId, owner.Id)
+            .With(g => g.Name, "Group With Members")
+            .Without(g => g.SharedSubscriptions)
+            .With(g => g.Members, allMembers) 
+            .Create();
+        
+        var usersToSave = new List<User> { owner };
+        usersToSave.AddRange(memberUsers);
+        await db.Users.AddRangeAsync(usersToSave);
+
+        
+        await db.UserGroups.AddAsync(group);
+        await db.SaveChangesAsync(default);
+        
+        return new UserGroupSeedEntity
+        {
+            User = owner,
+            Group = group,
+            Members = allMembers,
+            Subscriptions = new()
+        };
+    }
+    
+    public async Task<SubscriptionModel> AddSubscription()
+    {
+        using var scope = CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        
+        var user = _fixture.Build<UserModel>()
+            .Without(u => u.Groups)
+            .Without(u => u.Subscriptions)
+            .Create();
+
+        await db.Users.AddAsync(user);
+        await db.SaveChangesAsync(default);
+        
+        var subscription = _fixture.Build<SubscriptionModel>()
+            .With(s => s.UserId, user.Id)
+            .Without(s => s.User)
+            .Create();
+
+        await db.Subscriptions.AddAsync(subscription);
+        await db.SaveChangesAsync(default);
+
+        return subscription;
+    }
+    
+    public async Task<CreateGroupMemberDto> AddCreateGroupMemberDto(Guid groupId)
+    {
+        using var scope = CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        var user = _fixture.Build<UserModel>()
+            .Without(u => u.Groups)
+            .Without(u => u.Subscriptions)
+            .Create();
+
+        await db.Users.AddAsync(user);
+        await db.SaveChangesAsync(default);
+
+        return new CreateGroupMemberDto
+        {
+            UserId = user.Id,
+            GroupId = groupId,
+            Role = MemberRole.Participant
+        };
+    }
+
+    public async Task<UserGroupSeedEntity> AddUserGroupAndUser()
+    {
+        using var scope = CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        var user = _fixture.Build<UserModel>()
+            .Without(u => u.Groups)
+            .Without(u => u.Subscriptions)
+            .Create();
+
+        await db.Users.AddAsync(user);
+        await db.SaveChangesAsync(default);
+
+        var group = _fixture.Build<Group>()
+            .With(g => g.UserId, user.Id)
+            .With(g => g.Name, "Group Without Members")
+            .Create();
+
+        await db.UserGroups.AddAsync(group);
+        await db.SaveChangesAsync(default);
+
+        return new UserGroupSeedEntity
+        {
+            User = user,
+            Group = group,
+            Members = new(),
+            Subscriptions = new()
+        };
+    }
+    
+    public async Task<GroupMember> AddMemberOnly()
+    {
+        using var scope = CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+        
+        var user = _fixture.Build<UserModel>()
+            .Without(u => u.Groups)
+            .Without(u => u.Subscriptions)
+            .Create();
+
+        await db.Users.AddAsync(user);
+        await db.SaveChangesAsync(default);
+        
+        var group = _fixture.Build<Group>()
+            .With(g => g.UserId, user.Id)
+            .Without(g => g.Members)
+            .Without(g => g.SharedSubscriptions)
+            .Create();
+
+        await db.UserGroups.AddAsync(group);
+        await db.SaveChangesAsync(default);
+        
+        var member = _fixture.Build<GroupMember>()
+            .With(m => m.UserId, user.Id)
+            .With(m => m.GroupId, group.Id)
+            .With(m => m.Role, MemberRole.Participant)
+            .Without(m => m.User)
+            .Without(m => m.Group)
+            .Create();
+
+        await db.Members.AddAsync(member);
+        await db.SaveChangesAsync(default);
+
+        return member;
+    }
+    
+    public async Task<UserGroupSeedEntity> AddGroupWithSharedSubscription()
+    {
+        using var scope = CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        var user = _fixture.Build<UserModel>()
+            .Without(u => u.Groups)
+            .Without(u => u.Subscriptions)
+            .Create();
+
+        await db.Users.AddAsync(user);
+        
+        var subscription = _fixture.Build<SubscriptionModel>()
+            .With(s => s.UserId, user.Id)
+            .With(s => s.Name, "Shared Sub")
+            .With(s => s.Active, true)
+            .With(s => s.DueDate, DateOnly.FromDateTime(DateTime.Today.AddDays(10)))
+            .Without(s => s.User)
+            .Create();
+
+        await db.Subscriptions.AddAsync(subscription);
+        
+
+        var group = _fixture.Build<Group>()
+            .With(g => g.UserId, user.Id)
+            .With(g => g.Name, "Group With Shared Sub")
+            .With(g => g.SharedSubscriptions, [ subscription ])
+            .Create();
+
+        await db.UserGroups.AddAsync(group);
+        await db.SaveChangesAsync(default);
+
+        return new UserGroupSeedEntity
+        {
+            User = user,
+            Group = group,
+            Subscriptions = new List<SubscriptionModel> { subscription },
+            Members = new()
+        };
+    }
+    
+    public async Task<UserGroupSeedEntity> AddSeedUserOnly()
+    {
+        using var scope = CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        var user = _fixture.Build<UserModel>()
+            .Without(u => u.Groups)
+            .Create();
+
+        await dbContext.Users.AddAsync(user);
+        await dbContext.SaveChangesAsync(default);
+
+        return new UserGroupSeedEntity()
+        {
+            User = user,
+            Subscriptions = null!,
+            Group = null!,
+            Members = null!
+        };
+    }
+
+    public async Task<CreateUserGroupDto> AddCreateUserGroupDto()
+    {
+        var createDto = _fixture.Build<CreateUserGroupDto>()
+            .With(d => d.Name, "Created Group Name")
+            .Create();
+
+        return createDto;
+    }
+
+    public async Task<UpdateUserGroupDto> AddUpdateUserGroupDto(Guid groupId)
+    {
+        var updateDto = _fixture.Build<UpdateUserGroupDto>()
+            .With(d => d.Id, groupId)
+            .With(d => d.Name, "Updated Group Name")
+            .Create();
+
+        return updateDto;
+    }
+    
+    public async Task ClearTestDataWithDependencies()
+    {
+        using var scope = CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<SubsDbContext>();
+
+        dbContext.UserGroups.RemoveRange(dbContext.UserGroups.ToList());
+        dbContext.Subscriptions.RemoveRange(dbContext.Subscriptions.ToList());
+        dbContext.Members.RemoveRange(dbContext.Members.ToList());
+        dbContext.Users.RemoveRange(dbContext.Users.ToList());
+
+        await dbContext.SaveChangesAsync(default);
+    }
+}

--- a/SubsTracker.IntegrationTests/Subscription/SubscriptionsControllerTests.cs
+++ b/SubsTracker.IntegrationTests/Subscription/SubscriptionsControllerTests.cs
@@ -1,5 +1,3 @@
-using SubsTracker.IntegrationTests.Helpers.Subscription;
-
 namespace SubsTracker.IntegrationTests.Subscription;
 
 public class SubscriptionsControllerTests : IClassFixture<TestsWebApplicationFactory>, IAsyncDisposable

--- a/SubsTracker.IntegrationTests/Subscription/SubscriptionsControllerTests.cs
+++ b/SubsTracker.IntegrationTests/Subscription/SubscriptionsControllerTests.cs
@@ -1,6 +1,6 @@
 namespace SubsTracker.IntegrationTests.Subscription;
 
-public class SubscriptionsControllerTests : IClassFixture<TestsWebApplicationFactory>, IAsyncDisposable
+public class SubscriptionsControllerTests : IClassFixture<TestsWebApplicationFactory>
 {
     private readonly TestsWebApplicationFactory _factory;
     private readonly HttpClient _client;
@@ -134,12 +134,5 @@ public class SubscriptionsControllerTests : IClassFixture<TestsWebApplicationFac
 
         //Assert
         await _assertHelper.GetUpcomingBillsHappyPathAssert(response, upcoming);
-    }
-    
-    public async ValueTask DisposeAsync()
-    {
-        await _dataSeedingHelper.ClearTestData();
-        _client.Dispose();
-        _factory.Dispose();
     }
 }

--- a/SubsTracker.IntegrationTests/TestsWebApplicationFactory.cs
+++ b/SubsTracker.IntegrationTests/TestsWebApplicationFactory.cs
@@ -21,7 +21,7 @@ public class TestsWebApplicationFactory : WebApplicationFactory<Program>
     
                 services.AddDbContext<SubsDbContext>(options =>
                 {
-                    options.UseInMemoryDatabase("InMemoryDbContextTest");
+                    options.UseInMemoryDatabase(DatabaseConstant.InMemoryDbName);
                 });
             }));
     }

--- a/SubsTracker.IntegrationTests/UserGroup/UserGroupsControllerTests.cs
+++ b/SubsTracker.IntegrationTests/UserGroup/UserGroupsControllerTests.cs
@@ -1,0 +1,183 @@
+namespace SubsTracker.IntegrationTests.UserGroup;
+
+public class UserGroupsControllerTests : IClassFixture<TestsWebApplicationFactory>
+{
+    private readonly TestsWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private readonly UserGroupTestsDataSeedingHelper _dataSeedingHelper;
+    private readonly UserGroupTestsAssertionHelper _assertHelper;
+
+    public UserGroupsControllerTests(TestsWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = _factory.CreateClient();
+        _dataSeedingHelper = new UserGroupTestsDataSeedingHelper(factory);
+        _assertHelper = new UserGroupTestsAssertionHelper(factory);
+    }
+    
+    [Fact]
+    public async Task GetById_WhenValid_ReturnsCorrectGroup()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddOnlyUserGroup();
+
+        //Act
+        var response = await _client.GetAsync($"{EndpointConst.Group}/{seedData.Group.Id}");
+
+        //Assert
+        await _assertHelper.GetByIdHappyPathAssert(response, seedData.Group);
+    }
+
+    [Fact]
+    public async Task GetAll_WhenFilteredByName_ReturnsMatchingGroup()
+    {
+        //Arrange
+        await _dataSeedingHelper.ClearTestDataWithDependencies();
+        var seedData = await _dataSeedingHelper.AddOnlyUserGroup();
+
+        //Act
+        var response = await _client.GetAsync($"{EndpointConst.Group}?name={seedData.Group.Name}");
+
+        //Assert
+        await _assertHelper.GetAllHappyPathAssert(response, seedData.Group.Name);
+    }
+
+    [Fact]
+    public async Task GetAll_WhenFilteredByNonExistentName_ReturnsEmptyList()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddOnlyUserGroup();
+
+        //Act
+        var response = await _client.GetAsync($"{EndpointConst.Group}?name=NonExistent");
+
+        //Assert
+        await _assertHelper.GetAllSadPathAssert(response);
+    }
+
+    [Fact]
+    public async Task Create_WhenValidData_ReturnsCreatedGroup()
+    {
+        //Arrange
+        await _dataSeedingHelper.ClearTestDataWithDependencies();
+        var createDto = await _dataSeedingHelper.AddCreateUserGroupDto();
+        var seedUser = await _dataSeedingHelper.AddSeedUserOnly();
+
+        //Act
+        var response = await _client.PostAsJsonAsync($"{EndpointConst.Group}/{seedUser.User.Id}/create", createDto);
+
+        //Assert
+        await _assertHelper.CreateHappyPathAssert(response, createDto);
+    }
+
+    [Fact]
+    public async Task Update_WhenValidData_ReturnsUpdatedGroup()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddOnlyUserGroup();
+        var updateDto = await _dataSeedingHelper.AddUpdateUserGroupDto(seedData.Group.Id);
+
+        //Act
+        var response = await _client.PutAsJsonAsync($"{EndpointConst.Group}/{seedData.Group.Id}", updateDto);
+
+        //Assert
+        await _assertHelper.UpdateHappyPathAssert(response, seedData.Group.Id, "Updated Group Name");
+    }
+
+    [Fact]
+    public async Task Delete_WhenValidId_RemovesGroup()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddOnlyUserGroup();
+
+        //Act
+        var response = await _client.DeleteAsync($"{EndpointConst.Group}/{seedData.Group.Id}");
+
+        //Assert
+        await _assertHelper.DeleteHappyPathAssert(response, seedData.Group.Id);
+    }
+    
+    [Fact]
+    public async Task GetAllMembers_WhenFilteredByRole_ReturnsCorrectMember()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddUserGroupWithMembers();
+        var targetRole = MemberRole.Admin;
+
+        //Act
+        var response = await _client.GetAsync($"{EndpointConst.Group}/members?role={targetRole}");
+
+        //Assert
+        await _assertHelper.GetAllMembersHappyPathAssert(response, seedData, targetRole);
+    }
+    
+    [Fact]
+    public async Task JoinGroup_WhenValidData_AddsMember()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddUserGroupAndUser();
+        var createDto = await _dataSeedingHelper.AddCreateGroupMemberDto(seedData.Group.Id);
+
+        //Act
+        var response = await _client.PostAsJsonAsync($"{EndpointConst.Group}/join", createDto);
+
+        //Assert
+        await _assertHelper.JoinGroupHappyPathAssert(response, createDto);
+    }
+    
+    [Fact]
+    public async Task LeaveGroup_WhenValid_RemovesMember()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddUserGroupWithMembers();
+        var member = seedData.Members.FirstOrDefault();
+
+        //Act
+        var response = await _client.DeleteAsync($"{EndpointConst.Group}/leave?groupId={member.GroupId}&userId={member.UserId}");
+        
+        //Assert
+        await _assertHelper.LeaveGroupHappyPathAssert(response, member.GroupId, member.UserId);
+    }
+    
+    [Fact]
+    public async Task ChangeRole_WhenValid_UpdatesMemberRole()
+    {
+        //Arrange
+        await _dataSeedingHelper.ClearTestDataWithDependencies();
+        var member = await _dataSeedingHelper.AddMemberOnly();
+
+        //Act
+        var response = await _client.PatchAsync($"{EndpointConst.Group}/members/{member.Id}/role", null);
+
+        //Assert
+        await _assertHelper.ChangeRoleHappyPathAssert(response, MemberRole.Moderator);
+    }
+    
+    [Fact]
+    public async Task ShareSubscription_WhenValid_AddsToGroup()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddGroupWithSharedSubscription();
+        var subscription = await _dataSeedingHelper.AddSubscription();
+
+        //Act
+        var response = await _client.PostAsync($"{EndpointConst.Group}/share?groupId={seedData.Group.Id}&subscriptionId={subscription.Id}", null);
+
+        //Assert
+        await _assertHelper.ShareSubscriptionHappyPathAssert(response);
+    }
+    
+    [Fact]
+    public async Task UnshareSubscription_WhenValid_RemovesFromGroup()
+    {
+        //Arrange
+        var seedData = await _dataSeedingHelper.AddGroupWithSharedSubscription();
+        var subscription = seedData.Group.SharedSubscriptions.First();
+
+        //Act
+        var response = await _client.PostAsync($"{EndpointConst.Group}/unshare?groupId={seedData.Group.Id}&subscriptionId={subscription.Id}", null);
+
+        //Assert
+        await _assertHelper.UnshareSubscriptionHappyPathAssert(response);
+    }
+}

--- a/SubsTracker.UnitTests/UserGroupService/UserGroupServiceTestsBase.cs
+++ b/SubsTracker.UnitTests/UserGroupService/UserGroupServiceTestsBase.cs
@@ -1,9 +1,11 @@
+using SubsTracker.DAL.Repository;
+
 namespace SubsTracker.UnitTests.UserGroupService;
 
 public class UserGroupServiceTestsBase
 {
     protected readonly IFixture _fixture;
-    protected readonly IRepository<UserGroup> _repository;
+    protected readonly IUserGroupRepository _repository;
     protected readonly IRepository<User> _userRepository;
     protected readonly ISubscriptionRepository _subscriptionRepository;
     protected readonly IGroupMemberService _memberService;
@@ -19,14 +21,14 @@ public class UserGroupServiceTestsBase
             .ForEach(b => _fixture.Behaviors.Remove(b));
         _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
         
-        _repository = Substitute.For<IRepository<UserGroup>>();
+        _repository = Substitute.For<IUserGroupRepository>();
         _userRepository = Substitute.For<IRepository<User>>();
         _subscriptionRepository = Substitute.For<ISubscriptionRepository>();
         _mapper = Substitute.For<IMapper>();
         _memberService = Substitute.For<IGroupMemberService>();
         
         _service = new BLL.Services.User.UserGroupService(
-            _repository, 
+            _repository,
             _userRepository, 
             _subscriptionRepository, 
             _memberService, 


### PR DESCRIPTION
## Changelog

#### Setup changes:
- add DataSeedEntity for UserGroupsControllerTests
- add UserGroupsTestsDataSeedingHelper
- add UserGroupsTestsAssertionsHelper
- add UsersGroupsControllerTests class
---
#### Tests:
- add GetById test
- add GetAll tests
- add GetAllMembers test
- add Create test
- add Update test
- add Delete test
- add JoinGroup test
- add LeaveGroup test
- add ChangeRole test
- add ShareSubscription test
- add UnshareSubscription test
---
#### UserGroupRepository
- add UserGroupRepository with correct implementation of GetById method for UserGroup
- add related interfaces
- correct related interfaces
- correct related services
- add corrections to tests
---
#### Other
- delete unnecessary interface IAsyncDisposable in SubscriptionsControllerTests